### PR TITLE
broadcast status.json changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-*No unreleased changes*
+- Added broadcasting of the contents of ancillary files (e.g. `Status.json`) as events
 
 ## [3.0.1] - 2019-03-10
 ### Fixed

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -20,6 +20,13 @@ const JOURNAL_SERVER_PORT = 31337;
 const JOURNAL_DIR = join(homedir(), 'Saved Games', 'Frontier Developments', 'Elite Dangerous');
 
 /**
+ * List of ancillary files to also include in the event broadcast
+ * @type {Array}
+ */
+
+const ANCILLARY_FILES = ['Cargo.json', 'Market.json', 'ModulesInfo.json', 'Outfitting.json', 'Shipyard.json', 'Status.json'];
+
+/**
  * Default Journal Event subscription list for clients
  * @type {Array}
  */
@@ -148,6 +155,7 @@ module.exports = {
   JOURNAL_DIR,
   JOURNAL_FILE_REGEX,
   JOURNAL_WATCH_INTERVAL,
+  ANCILLARY_FILES,
 
   // heartbeat
   SERVER_HEARTBEAT_INTERVAL,

--- a/src/index.js
+++ b/src/index.js
@@ -555,6 +555,16 @@ class EliteDangerousJournalServer {
       this.getJournalUpdate();
     } else {
       console.log(`${chalk.green(`Filesystem event ${chalk.red(event)} occurred for`)} ${chalk.magenta(filepath)}`);
+      const baseName = path.basename(filepath).toLowerCase();
+      if (baseName === 'status.json') {
+        const statusLines = fs.readFileSync(filepath, 'utf-8').split('\n').filter(item => item.trim());
+        if (statusLines && statusLines.length) {
+          const formattedStatus = JSON.parse(statusLines[0]);
+          if (formattedStatus) {
+            this.broadcast(formattedStatus);
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #39 

**Proposed Changes**:

* Whenever a change is observed on `status.json`, read it, parse it and broadcast it. Clients will see an event of type `Status`.

---

@DVDAGames/ed-journal-server-maintainers
