### PR TITLE
Wrap parsing of files in exception handler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -574,9 +574,20 @@ class EliteDangerousJournalServer {
   getFileUpdate(filepath) {
     const baseName = path.basename(filepath).toLowerCase();
     if (this.ancillaryFiles[baseName]) {
-      const parsedEvent = JSON.parse(fs.readFileSync(filepath, 'utf-8'));
-      if (parsedEvent) {
-        this.broadcast(Object.assign({}, parsedEvent, this.ancillaryFiles[baseName]));
+      try {
+        const parsedEvent = JSON.parse(fs.readFileSync(filepath, 'utf-8'));
+        if (parsedEvent) {
+          this.broadcast(Object.assign({}, parsedEvent, this.ancillaryFiles[baseName]));
+        }
+      }
+      catch (err) {
+        /* If the file is in the middle of being flushed to disk, we can
+         * get 'SyntaxError: Unexpected end of JSON input' in JSON.parse().
+         */
+        if (err.name != 'SyntaxError') {
+          throw err;
+        }
+        console.log(`${chalk.red('Ignoring error:')} ${chalk.magenta(err)}`);
       }
     }
   }


### PR DESCRIPTION
Sometimes, the file is not fully written to disk, and the JSON is therefore invalid. This MR catches that case and ignores that particular file update. Happens fairly often with `status.json`. A subsequent update to the file might read it at a better point in time and the parsing will succeed.

Fixes #48 

**Proposed Changes**:

Wrap the JSON parsing in exception handler, ignore the "SyntaxError" exception caused by malformed/incomplete JSON.

The log message highlights when the exception occurs. It should get removed/squelched it before final merge.

---

@DVDAGames/ed-journal-server-maintainers
